### PR TITLE
fix sideEffects in package.json

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "types": "src/index.ts",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
Imported CSS from packages with sideEffects set to false is omitted from bundle when using `import` syntax.

Css should absolutely be marked as a side effect, i.e. `"sideEffects": ["*.css"]`

