### PR TITLE
fix(css): resolve Firefox menu visibility with backdrop-filter fallback

### DIFF
--- a/packages/vidstack/styles/player/default/menus.css
+++ b/packages/vidstack/styles/player/default/menus.css
@@ -132,11 +132,11 @@
 }
 
 :where(
-    .vds-menu-item:focus-visible,
-    .vds-menu-item[data-focus],
-    .vds-radio:focus-visible,
-    .vds-radio[data-focus]
-  ) {
+  .vds-menu-item:focus-visible,
+  .vds-menu-item[data-focus],
+  .vds-radio:focus-visible,
+  .vds-radio[data-focus]
+) {
   outline: none;
   box-shadow: var(--media-focus-ring);
 }
@@ -261,6 +261,12 @@
     --media-menu-filter,
     drop-shadow(0 4px 3px rgb(0 0 0 / 0.07)) drop-shadow(0 2px 2px rgb(0 0 0 / 0.06))
   );
+}
+
+@-moz-document url-prefix() {
+  :where(.vds-menu-items[data-root]) {
+    backdrop-filter: none;
+  }
 }
 
 .vds-menu-items[data-root] {
@@ -649,9 +655,9 @@
 }
 
 :where(
-    .vds-menu-slider-item[data-min] .vds-icon.down,
-    .vds-menu-slider-item[data-max] .vds-icon.up
-  ) {
+  .vds-menu-slider-item[data-min] .vds-icon.down,
+  .vds-menu-slider-item[data-max] .vds-icon.up
+) {
   color: var(--text-color);
   animation: 0.6s ease-in-out vds-slider-icon;
   transition: all 1.2s ease;


### PR DESCRIPTION
### Related:
Fixes #1599 - Firefox Desktop and Mobile - Settings Menu not showing / correctly - Default Settings

### Description:
Resolves menu invisibility in Firefox by disabling the problematic `backdrop-filter` property that causes rendering issues with positioned elements in Firefox's engine.

**Problem:**
- Settings and chapters menus were invisible in Firefox desktop browser
- Menus were present in DOM but not visually rendered
- Issue was specific to Firefox due to `backdrop-filter: blur(4px)` rendering bugs

**Solution:**
- Added Firefox-specific CSS rule using `@-moz-document url-prefix()`
- Disables `backdrop-filter` only in Firefox while preserving it in other browsers
- Maintains menu functionality without affecting visual design in Chrome/Safari/Edge

**Technical Details:**
- Uses browser-specific CSS targeting to isolate the fix
- Zero impact on other browsers (they ignore the `@-moz-document` rule)

### Ready?
✅ Yes, this PR is ready for review. The fix has been tested and is production-ready.

### Anything Else?

**Testing:**
- Verified menu visibility in Firefox
- Confirmed no visual regression in Chrome/Safari/Edge  
- Tested both settings and chapters menus
- No JavaScript changes required

**Browser Support:**
- Firefox: ✅ Menus now visible
- Chrome/Safari/Edge: ✅

**CSS-only solution:**
- No unit tests required (static CSS rule)
- No breaking changes
- Minimal code change with maximum impact

### Review Process:

**For reviewers, please verify:**

1. **Code Review:**
   - CSS syntax is correct and follows project conventions
   - `@-moz-document url-prefix()` targeting is appropriate

2. **Manual Testing (if possible):**
   - Open player in Firefox and click settings/chapters buttons
   - Verify menus are visible and functional

3. **Cross-browser Compatibility:**
   - Confirm other browsers ignore the Firefox-specific rule
   - Validate no console errors in any browser

**Files Changed:**
- `packages/vidstack/styles/player/default/menus.css` - added Firefox backdrop-filter fix