### PR TITLE
fix(css): vds-youtube height

### DIFF
--- a/packages/vidstack/styles/player/base.css
+++ b/packages/vidstack/styles/player/base.css
@@ -101,7 +101,7 @@
 }
 
 iframe.vds-youtube[data-no-controls] {
-  height: 1000%;
+  height: 100%;
 }
 
 .vds-blocker {


### PR DESCRIPTION
### Related:

Fixes #1719

### Description:

Fixed a typo in CSS where `iframe.vds-youtube[data-no-controls]` had `height: 1000%` instead of the correct `height: 100%`.

### Ready?

Yes, this PR is ready for review. It's a simple typo fix with a clear before/after change.

### Anything Else?

This is a straightforward bug fix that corrects an obvious typo. The change affects YouTube iframe elements specifically when they have the `data-no-controls` attribute.

### Review Process:

- Verify that the CSS change from `height: 1000%` to `height: 100%` is correct
- Confirm that YouTube iframes with `data-no-controls` attribute now display with proper height
- Check that no other styling is affected by this change