### PR TITLE
fix(youtube): add allowSeekAhead parameter to seekTo command

### DIFF
--- a/packages/vidstack/src/providers/youtube/embed/command.ts
+++ b/packages/vidstack/src/providers/youtube/embed/command.ts
@@ -13,7 +13,7 @@ export type YouTubeCommand =
 export interface YouTubeCommandArg {
   playVideo: void;
   pauseVideo: void;
-  seekTo: number;
+  seekTo: [number, boolean];
   mute: void;
   unMute: void;
   setVolume: number;

--- a/packages/vidstack/src/providers/youtube/provider.ts
+++ b/packages/vidstack/src/providers/youtube/provider.ts
@@ -135,7 +135,7 @@ export class YouTubeProvider
   }
 
   setCurrentTime(time: number) {
-    this.#remote('seekTo', time);
+    this.#remote('seekTo', [time, true]);
     this.#ctx.notify('seeking', time);
   }
 
@@ -207,10 +207,12 @@ export class YouTubeProvider
 
     promises.push(promise);
 
+    const args = Array.isArray(arg) ? arg : arg ? [arg] : undefined;
+
     this.postMessage({
       event: 'command',
       func: command,
-      args: arg ? [arg] : undefined,
+      args,
     });
 
     return promise.promise;


### PR DESCRIPTION
### Related:
Closes: #1714

### Description:
**Fix YouTube Provider Seek Issues by adding `allowSeekAhead` parameter**

This PR fixes a critical issue in the YouTube provider where seeking operations (especially `currentTime = 0`) would cause the player to get stuck in a "waiting" state or throw `Uncaught TypeError: K.Wp.o1 is not a function` errors.

**Root Cause:**
The YouTube iframe API's `seekTo()` method requires two parameters: `seekTo(seconds, allowSeekAhead)`. Passing the first parameter, causing YouTube to reject seeks to unbuffered content and leading to corrupted internal state.
[Here](https://developers.google.com/youtube/iframe_api_reference#seekTo) the YouTube documentation.

**Changes Made:**
1. **Updated YouTube provider's `setCurrentTime()` method** to pass `allowSeekAhead: true`
2. **Modified command type definitions** to support multiple arguments for `seekTo`
3. **Enhanced `#remote()` method** to handle `seekTo` specially without double-wrapping arguments
4. **Added proper YouTube API compliance** by passing both required parameters

**Key Fix:**
```typescript
// Before (broken):
this.#remote('seekTo', time);

// After (fixed):
this.#remote('seekTo', [time, true]); // enables allowSeekAhead
```
This ensures YouTube receives `player.seekTo(time, true);` with the correct parameters, allowing seeks to any position regardless of buffer state.

### Ready?
Yes - This PR is ready for review. The fix has been tested and resolves the YouTube seeking issues.

### Anything Else?
- All existing functionality preserved
- Only affects YouTube provider behavior
- Backward compatible with current API