### PR TITLE
feat(sandbox): add URL params support for testing

### DIFF
--- a/packages/vidstack/.templates/sandbox/main.ts
+++ b/packages/vidstack/.templates/sandbox/main.ts
@@ -47,7 +47,25 @@ liveSrcButton?.addEventListener('click', () => changeSource('live'));
 youtubeSrcButton?.addEventListener('click', () => changeSource('youtube'));
 vimeoSrcButton?.addEventListener('click', () => changeSource('vimeo'));
 
-changeSource('audio');
+// URL query param support for testing
+// ?src=vimeo|youtube|hls|video|audio|live|dash
+// ?autoplay - enable autoplay
+// ?muted - start muted
+const params = new URLSearchParams(window.location.search);
+
+if (params.has('autoplay')) player.autoplay = true;
+if (params.has('muted')) player.muted = true;
+
+const srcParam = params.get('src');
+changeSource(srcParam || 'audio');
+
+player.addEventListener('auto-play', (e) => {
+  console.log('[auto-play]', e.detail);
+});
+
+player.addEventListener('auto-play-fail', (e) => {
+  console.log('[auto-play-fail]', e.detail);
+});
 
 function changeSource(type: string) {
   switch (type) {


### PR DESCRIPTION
## Summary
- Add URL query parameter support to the sandbox for easier testing:
  - `?src=vimeo|youtube|hls|video|audio|live|dash` - select source
  - `?autoplay` - enable autoplay
  - `?muted` - start muted
- Log `auto-play` and `auto-play-fail` events to console

## Why add this?

This helps testing (and thus developing) features such as autoplay. I need that to make another issue apparent, for which I'll create a PR shortly. If interested, see its' description below.

### Known Issue - Vimeo Autoplay Muted State

This PR also makes a bug in the Vimeo provider visible: when a video starts with autoplay, it may be muted by the browser (due to Chrome's autoplay policy), yet the player UI shows it as unmuted.

**Repro**: Visit `http://localhost:3100/sandbox/index.html?src=vimeo&autoplay`

**Issue**: Vidstack's `onAutoPlay` event reports `muted: false` even when Chrome forces the Vimeo iframe to mute due to autoplay policy.

**Root cause**: For Vimeo iframe embeds, Chrome's autoplay policy applies inside the iframe and Vimeo handles muting internally. Vidstack reports its own requested state (`muted: false, volume: 1`), not what Vimeo actually did.

**Expected behavior**: Either:
1. Vidstack should detect Vimeo's actual muted state (if possible)
2. Document this limitation in the autoplay docs
3. Provide a way to detect "autoplay succeeded but with silent audio"
