### PR TITLE
fix(react): use useLayoutEffect for hasMounted to prevent source element race condition

### DIFF
--- a/packages/react/src/components/provider.tsx
+++ b/packages/react/src/components/provider.tsx
@@ -101,7 +101,7 @@ function MediaOutlet({ provider, mediaProps, iframeProps }: MediaOutletProps) {
     });
   }, [isGoogleCast]);
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     setHasMounted(true);
   }, []);
 


### PR DESCRIPTION
## Summary

- Use `useLayoutEffect` instead of `useEffect` for `setHasMounted(true)` in `MediaOutlet` to prevent a race condition with hls.js's `removeSourceChildren()`

## Problem

On iOS 17+, hls.js uses `ManagedMediaSource` which calls `removeSourceChildren()` during initialization, removing all `<source>` elements from the `<video>` element — including ones rendered by React (when `!hasMounted`).

The current `useEffect` for `setHasMounted(true)` triggers a batched re-render that may be deferred by React's scheduler (especially during unmount→remount transitions like Next.js page navigation). This allows the RAF-scheduled hls.js initialization to fire first, removing React's `<source>` elements before React can reconcile them, resulting in a `NotFoundError` from `removeChild`.

### Timeline (before fix)

```
[commit]  <video><source>...</source></video>  (React tracks <source> in fiber tree)
[paint]   browser paint
[effect]  setHasMounted(true) → batched re-render scheduled
          React scheduler yields (>5ms due to unmount cleanup work)
[RAF]     hls.js init → removeSourceChildren() → removes React's <source>
[task]    React re-render → removeChild(<source>) → NotFoundError!
```

### Timeline (after fix)

```
[commit]  <video><source>...</source></video>
[layout]  setHasMounted(true) → synchronous re-render → <source> removed
[paint]   browser paint
[RAF]     hls.js init → removeSourceChildren() → nothing to remove
```

## Notes

- SSR behavior is preserved: `useLayoutEffect` does not run on the server, so `<source>` elements are still rendered in SSR HTML for preloading
- The `useLayoutEffect` re-render is lightweight (only removes `<source>` children), so no visible paint delay

Closes #1521