### PR TITLE
fix(vidstack): handle fullscreen dispose rejection

### DIFF
--- a/packages/vidstack/src/foundation/fullscreen/controller.ts
+++ b/packages/vidstack/src/foundation/fullscreen/controller.ts
@@ -1,6 +1,6 @@
 import fscreen from 'fscreen';
 import { onDispose, ViewController } from 'maverick.js';
-import { EventsController, listenEvent } from 'maverick.js/std';
+import { EventsController, listenEvent, noop } from 'maverick.js/std';
 
 import type { FullscreenEvents } from './events';
 
@@ -35,8 +35,8 @@ export class FullscreenController
     onDispose(this.#onDisconnect.bind(this));
   }
 
-  async #onDisconnect() {
-    if (CAN_FULLSCREEN) await this.exit();
+  #onDisconnect() {
+    if (CAN_FULLSCREEN) void this.exit().catch(noop);
   }
 
   #onChange(event: Event) {


### PR DESCRIPTION
## Summary

- Make the fullscreen dispose handler synchronous.
- Explicitly sink `exit()` rejections with `void this.exit().catch(noop)` during disposal.

Fixes #1789

## Validation

- `pnpm --filter vidstack typecheck` passed.
- Initial validation attempt failed because the isolated worktree had no `node_modules` and `tsgo` was missing; installed dependencies with `pnpm install --frozen-lockfile` and reran successfully.
