### PR TITLE
fix(react): stabilize media outlet provider refs

### DIFF
--- a/packages/react/src/components/provider.tsx
+++ b/packages/react/src/components/provider.tsx
@@ -96,9 +96,12 @@ function MediaOutlet({ provider, mediaProps, iframeProps }: MediaOutletProps) {
     [googleCastIconPaths, setGoogleCastIconPaths] = React.useState(''),
     [hasMounted, setHasMounted] = React.useState(false);
 
-  const loadProviderRef = React.useCallback((el: HTMLElement | null) => {
-    provider.load(el);
-  }, [provider]);
+  const loadProviderRef = React.useCallback(
+    (el: HTMLElement | null) => {
+      provider.load(el);
+    },
+    [provider],
+  );
 
   React.useEffect(() => {
     if (!isGoogleCast || googleCastIconPaths) return;
@@ -113,10 +116,7 @@ function MediaOutlet({ provider, mediaProps, iframeProps }: MediaOutletProps) {
 
   if (isGoogleCast) {
     return (
-      <div
-        className="vds-google-cast"
-        ref={loadProviderRef}
-      >
+      <div className="vds-google-cast" ref={loadProviderRef}>
         <Icon paths={googleCastIconPaths} />
         {$remoteInfo?.deviceName ? (
           <span className="vds-google-cast-info">
@@ -131,10 +131,7 @@ function MediaOutlet({ provider, mediaProps, iframeProps }: MediaOutletProps) {
   if (isRemotion) {
     return (
       <div data-remotion-canvas>
-        <div
-          data-remotion-container
-          ref={loadProviderRef}
-        >
+        <div data-remotion-container ref={loadProviderRef}>
           {isRemotionProvider($provider) && $providerSetup
             ? React.createElement($provider.render)
             : null}

--- a/packages/react/src/components/provider.tsx
+++ b/packages/react/src/components/provider.tsx
@@ -96,6 +96,10 @@ function MediaOutlet({ provider, mediaProps, iframeProps }: MediaOutletProps) {
     [googleCastIconPaths, setGoogleCastIconPaths] = React.useState(''),
     [hasMounted, setHasMounted] = React.useState(false);
 
+  const loadProviderRef = React.useCallback((el: HTMLElement | null) => {
+    provider.load(el);
+  }, [provider]);
+
   React.useEffect(() => {
     if (!isGoogleCast || googleCastIconPaths) return;
     import('media-icons/dist/icons/chromecast.js').then((mod) => {
@@ -111,9 +115,7 @@ function MediaOutlet({ provider, mediaProps, iframeProps }: MediaOutletProps) {
     return (
       <div
         className="vds-google-cast"
-        ref={(el) => {
-          provider.load(el);
-        }}
+        ref={loadProviderRef}
       >
         <Icon paths={googleCastIconPaths} />
         {$remoteInfo?.deviceName ? (
@@ -131,9 +133,7 @@ function MediaOutlet({ provider, mediaProps, iframeProps }: MediaOutletProps) {
       <div data-remotion-canvas>
         <div
           data-remotion-container
-          ref={(el) => {
-            provider.load(el);
-          }}
+          ref={loadProviderRef}
         >
           {isRemotionProvider($provider) && $providerSetup
             ? React.createElement($provider.render)
@@ -157,9 +157,7 @@ function MediaOutlet({ provider, mediaProps, iframeProps }: MediaOutletProps) {
           tabIndex: !$nativeControls ? -1 : undefined,
           'aria-hidden': 'true',
           'data-no-controls': !$nativeControls ? '' : undefined,
-          ref(el: HTMLElement) {
-            provider.load(el);
-          },
+          ref: loadProviderRef,
         }),
         !$nativeControls && !isAudioView
           ? React.createElement('div', { className: 'vds-blocker' })
@@ -179,9 +177,7 @@ function MediaOutlet({ provider, mediaProps, iframeProps }: MediaOutletProps) {
                 ) : null,
               )
             : null,
-          ref(el: HTMLMediaElement) {
-            provider.load(el);
-          },
+          ref: loadProviderRef,
         })
       : null;
 }


### PR DESCRIPTION
## Summary
- Stabilize the `MediaOutlet` provider ref callback with `React.useCallback`.
- Reuse the stable loader for Google Cast, Remotion, iframe embeds, audio, and video provider refs.

Fixes #1790

## Validation
- `pnpm --filter @vidstack/react typecheck` passed.
