### PR TITLE
fix(vidstack): avoid tracked provider read in muted queue

### DIFF
--- a/packages/vidstack/src/components/player.ts
+++ b/packages/vidstack/src/components/player.ts
@@ -508,7 +508,9 @@ export class MediaPlayer
 
   #queueMutedUpdate(muted: boolean) {
     this.canPlayQueue.enqueue('muted', () => {
-      if (this.#provider) this.#provider.setMuted(muted);
+      peek(() => {
+        if (this.#provider) this.#provider.setMuted(muted);
+      });
     });
   }
 


### PR DESCRIPTION
## Summary

- Wrap `#queueMutedUpdate` provider access in `peek(() => { ... })` to avoid tracking the provider signal from queued callbacks.

## Validation

- `pnpm --filter vidstack typecheck` passed.

Fixes #1788