### PR TITLE
fix(vidstack): type legacy vite plugin

### DIFF
--- a/packages/vidstack/vite.config.ts
+++ b/packages/vidstack/vite.config.ts
@@ -2,6 +2,7 @@
 
 import { transform } from 'esbuild';
 import { defineConfig } from 'vite';
+import type { Plugin } from 'vite';
 
 const SERVER = !!process.env.SERVER;
 
@@ -38,7 +39,7 @@ export default defineConfig({
   plugins: [legacyPlugin()],
 });
 
-function legacyPlugin() {
+function legacyPlugin(): Plugin {
   return {
     name: 'legacy',
     enforce: 'pre',


### PR DESCRIPTION
## Summary

- Type the legacy Vite plugin helper as Vite's `Plugin` type.
- Keeps the `enforce: 'pre'` value checked against Vite's plugin contract.

Fixes #1792

## Validation

- `pnpm install --frozen-lockfile` succeeded in the isolated `fix/1792-vite-enforce-type` worktree.
- `pnpm exec tsgo -p tsconfig.json --noEmit` failed at the repository root with exit code 2 and 1035 diagnostic lines. The failures are broad existing root tsconfig issues: React TSX files are checked without `jsx`, Vitest globals are missing for test files, and `packages/vidstack/tsdown.config.ts` cannot find `rolldown` types. No diagnostics matched `packages/vidstack/vite.config.ts`, `legacyPlugin`, or `enforce`.
- `cd packages/vidstack && pnpm exec tsgo -p tsconfig.json --noEmit` passed.
