### PR TITLE
fix(react): track active text track dependency

### DIFF
--- a/packages/react/src/hooks/use-active-text-track.ts
+++ b/packages/react/src/hooks/use-active-text-track.ts
@@ -13,7 +13,7 @@ export function useActiveTextTrack(kind: TextTrackKind | TextTrackKind[]): TextT
 
   React.useEffect(() => {
     return watchActiveTextTrack(media.textTracks, kind, setTrack);
-  }, [kind]);
+  }, [media.textTracks, kind]);
 
   return track;
 }


### PR DESCRIPTION
## Summary
- Add `media.textTracks` to the `useActiveTextTrack` effect dependency array so the active text track watcher rebinds when the track list object changes.

Fixes #1785

## Validation
- `pnpm --filter @vidstack/react typecheck` passed.
