### PR TITLE
fix(react): clear media remote references on cleanup

### DIFF
--- a/packages/react/src/hooks/use-media-remote.ts
+++ b/packages/react/src/hooks/use-media-remote.ts
@@ -25,12 +25,18 @@ export function useMediaRemote(
   }
 
   React.useEffect(() => {
-    const ref = target && 'current' in target ? target.current : target,
+    const currentRemote = remote.current!,
+      ref = target && 'current' in target ? target.current : target,
       isPlayerRef = ref instanceof MediaPlayerInstance,
       player = isPlayerRef ? ref : media?.player;
 
-    remote.current!.setPlayer(player ?? null);
-    remote.current!.setTarget(ref ?? null);
+    currentRemote.setPlayer(player ?? null);
+    currentRemote.setTarget(ref ?? null);
+
+    return () => {
+      currentRemote.setPlayer(null);
+      currentRemote.setTarget(null);
+    };
   }, [media, target && 'current' in target ? target.current : target]);
 
   return remote.current;


### PR DESCRIPTION
## Summary

- Clear the captured `MediaRemoteControl` player and target references in the React effect cleanup.
- Preserve the existing player/target assignment behavior when the hook mounts or dependencies change.

Fixes #1784

## Validation

- `pnpm --filter @vidstack/react typecheck` passed.
- Note: the first typecheck attempt failed because the new linked worktree had no `node_modules` and `tsgo` was missing; reran successfully after `pnpm install --frozen-lockfile`.