### PR TITLE
fix(react): keep active state while focused

### DIFF
--- a/packages/react/src/hooks/use-dom.ts
+++ b/packages/react/src/hooks/use-dom.ts
@@ -81,7 +81,7 @@ export function useActive(el: Element | null) {
     isFocusIn = useFocusIn(el),
     prevMouseEnter = React.useRef(false);
 
-  if (prevMouseEnter.current && !isMouseEnter) return false;
+  if (prevMouseEnter.current && !isMouseEnter && !isFocusIn) return false;
 
   prevMouseEnter.current = isMouseEnter;
   return isMouseEnter || isFocusIn;

--- a/packages/vidstack/src/utils/dom.ts
+++ b/packages/vidstack/src/utils/dom.ts
@@ -369,10 +369,11 @@ export function useActive($el: ReadSignal<Element | null | undefined>) {
   let prevMouseEnter = false;
 
   return computed(() => {
-    const isMouseEnter = $isMouseEnter();
-    if (prevMouseEnter && !isMouseEnter) return false;
+    const isMouseEnter = $isMouseEnter(),
+      isFocusIn = $isFocusedIn();
+    if (prevMouseEnter && !isMouseEnter && !isFocusIn) return false;
     prevMouseEnter = isMouseEnter;
-    return isMouseEnter || $isFocusedIn();
+    return isMouseEnter || isFocusIn;
   });
 }
 


### PR DESCRIPTION
## Summary
- Keep `useActive` active when mouse leave fires while focus remains inside the element.
- Apply the same focus-aware active-state logic to the core web-component DOM utility.

Fixes #1782

## Validation
- `pnpm --filter @vidstack/react typecheck` passed
- `pnpm --filter vidstack typecheck` passed
