### PR TITLE
fix(vidstack): read canPlay signal in html play event

### DIFF
--- a/packages/vidstack/src/providers/html/html–media-events.ts
+++ b/packages/vidstack/src/providers/html/html–media-events.ts
@@ -190,7 +190,7 @@ export class HTMLMediaEvents {
   }
 
   #onPlay(event: Event) {
-    if (!this.#ctx.$state.canPlay) return;
+    if (!this.#ctx.$state.canPlay()) return;
     this.#ctx.notify('play', undefined, event);
   }
 


### PR DESCRIPTION
## Summary
- Read the `canPlay` signal in the HTML media `play` event guard before notifying `play`.

Fixes #1780

## Validation
- `pnpm install --frozen-lockfile` (needed because the linked worktree had no `node_modules`)
- `pnpm --filter vidstack typecheck` passed