### PR TITLE
fix(vidstack): resolve timed promise without rejection

### DIFF
--- a/packages/vidstack/src/utils/promise.test.ts
+++ b/packages/vidstack/src/utils/promise.test.ts
@@ -1,0 +1,32 @@
+import { timedPromise } from './promise';
+
+describe(timedPromise.name, function () {
+  beforeEach(function () {
+    vi.useFakeTimers();
+  });
+
+  afterEach(function () {
+    vi.useRealTimers();
+  });
+
+  it('resolves when the timeout callback returns void', async function () {
+    const callback = vi.fn();
+    const promise = timedPromise(callback, 1000);
+    const resolution = expect(promise.promise).resolves.toBeUndefined();
+
+    vi.advanceTimersByTime(1000);
+
+    await resolution;
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it('rejects when the timeout callback returns a rejection value', async function () {
+    const rejection = '';
+    const promise = timedPromise<void, string>(() => rejection, 1000);
+    const resolution = expect(promise.promise).rejects.toBe(rejection);
+
+    vi.advanceTimersByTime(1000);
+
+    await resolution;
+  });
+});

--- a/packages/vidstack/src/utils/promise.ts
+++ b/packages/vidstack/src/utils/promise.ts
@@ -5,7 +5,8 @@ export function timedPromise<Resolved, Rejected>(callback: () => Rejected | void
 
   setTimeout(() => {
     const rejection = callback();
-    if (rejection) promise.reject(rejection);
+    if (rejection !== undefined) promise.reject(rejection);
+    else promise.resolve();
   }, ms);
 
   return promise;


### PR DESCRIPTION
## Summary

- Resolve `timedPromise` when the timeout callback returns void.
- Reject with the returned callback value when a rejection value is provided.
- Add focused fake-timer coverage for the resolve and reject paths.

Fixes #1781

## Validation

- `pnpm --filter vidstack exec vitest --run src/utils/promise.test.ts` - passed, 1 file / 2 tests
- `pnpm --filter vidstack typecheck` - passed
