### PR TITLE
fix(vidstack): read slider intersection signal

### DIFF
--- a/packages/vidstack/src/components/ui/sliders/slider/slider-controller.ts
+++ b/packages/vidstack/src/components/ui/sliders/slider/slider-controller.ts
@@ -111,7 +111,7 @@ export class SliderController extends ViewController<
 
   #watchHidden() {
     const { hidden } = this.$props;
-    this.$state.hidden.set(hidden() || !this.#isVisible() || !this.#isIntersecting.bind(this));
+    this.$state.hidden.set(hidden() || !this.#isVisible() || !this.#isIntersecting());
   }
 
   #watchValue() {


### PR DESCRIPTION
## Summary
- Read the slider intersection signal value in #watchHidden instead of negating a bound function object.

Fixes #1779

## Validation
- pnpm --filter vidstack typecheck passed after installing dependencies with pnpm install --frozen-lockfile in the linked worktree.
- Initial typecheck attempt failed because the new worktree had no node_modules and tsgo was missing locally.