### PR TITLE
fix(vidstack): pass emptied event to notify

### DIFF
--- a/packages/vidstack/src/providers/html/html–media-events.ts
+++ b/packages/vidstack/src/providers/html/html–media-events.ts
@@ -157,7 +157,7 @@ export class HTMLMediaEvents {
     this.#ctx.notify('abort', undefined, event);
   }
 
-  #onEmptied() {
+  #onEmptied(event: Event) {
     this.#ctx.notify('emptied', undefined, event);
   }
 


### PR DESCRIPTION
## Summary
- Accept the native `emptied` event in `#onEmptied`.
- Pass that event through to `this.#ctx.notify("emptied", undefined, event)`.

Fixes #1778

## Validation
- `pnpm --filter vidstack typecheck` passed.
- Initial typecheck attempt failed before dependency install because the new linked worktree had no `node_modules` and `tsgo` was not found; after `pnpm install --frozen-lockfile`, the requested command passed.